### PR TITLE
Avoid stringly types in Service module by implementing several traits

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -1,18 +1,94 @@
 use request::ToParams;
+use errors::*;
+
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct ProviderKey(String);
+#[derive(Debug)]
+pub struct ServiceToken(String);
 
 #[derive(Debug)]
 pub enum Credentials {
-    ProviderKey(String),
-    ServiceToken(String),
+    ProviderKey(ProviderKey),
+    ServiceToken(ServiceToken),
+}
+
+// These trait impls provide a way to reference our types as &str
+impl AsRef<str> for ProviderKey {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for ServiceToken {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+// These trait impls provide a way to &str#parse()
+impl FromStr for ProviderKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<ProviderKey> {
+        Ok(ProviderKey(s.to_owned()))
+    }
+}
+
+impl FromStr for ServiceToken {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<ServiceToken> {
+        Ok(ServiceToken(s.to_owned()))
+    }
+}
+
+// These trait impls are similar to FromStr (but are infallible)
+impl<'a> From<&'a str> for ProviderKey where Self: FromStr {
+    fn from(s: &'a str) -> ProviderKey {
+        s.parse().unwrap()
+    }
+}
+
+impl<'a> From<&'a str> for ServiceToken where Self: FromStr {
+    fn from(s: &'a str) -> ServiceToken {
+        s.parse().unwrap()
+    }
+}
+
+// These trait impls take ownership of a given String
+impl From<String> for ProviderKey {
+    fn from(s: String) -> ProviderKey {
+        ProviderKey(s)
+    }
+}
+
+impl From<String> for ServiceToken {
+    fn from(s: String) -> ServiceToken {
+        ServiceToken(s)
+    }
+}
+
+impl Into<Credentials> for ProviderKey {
+    fn into(self) -> Credentials {
+        Credentials::ProviderKey(self)
+    }
+}
+
+impl Into<Credentials> for ServiceToken {
+    fn into(self) -> Credentials {
+        Credentials::ServiceToken(self)
+    }
 }
 
 impl Credentials {
-    pub fn from_key(key: String) -> Self {
-        Credentials::ProviderKey(key)
+    pub fn from_key<T: Into<ProviderKey>>(key: T) -> Self {
+        Credentials::ProviderKey(key.into())
     }
 
-    pub fn from_token(token: String) -> Self {
-        Credentials::ServiceToken(token)
+    pub fn from_token<T: Into<ServiceToken>>(token: T) -> Self {
+        Credentials::ServiceToken(token.into())
     }
 }
 
@@ -21,8 +97,8 @@ impl ToParams for Credentials {
         use self::Credentials::*;
 
         let (field, value) = match *self {
-            ProviderKey(ref key) => ("provider_key", key),
-            ServiceToken(ref token) => ("service_token", token)
+            ProviderKey(ref key) => ("provider_key", key.as_ref()),
+            ServiceToken(ref token) => ("service_token", token.as_ref())
         };
 
         vec![(field, value)]
@@ -30,20 +106,50 @@ impl ToParams for Credentials {
 }
 
 #[derive(Debug)]
+pub struct ServiceId(String);
+
+#[derive(Debug)]
 pub struct Service {
-    service_id: String,
+    service_id: ServiceId,
     creds: Credentials,
 }
 
+impl AsRef<str> for ServiceId {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl FromStr for ServiceId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<ServiceId> {
+        Ok(ServiceId(s.to_owned()))
+    }
+}
+
+impl<'a> From<&'a str> for ServiceId where Self: FromStr {
+    fn from(s: &'a str) -> ServiceId {
+        s.parse().unwrap()
+    }
+}
+
+impl From<String> for ServiceId {
+    fn from(s: String) -> ServiceId {
+        ServiceId(s)
+    }
+}
+
 impl Service {
-    pub fn new(service_id: String, creds: Credentials) -> Self {
+    pub fn new<T: Into<ServiceId>>(service_id: T, creds: Credentials) -> Self {
+        let service_id = service_id.into();
         Self { service_id, creds }
     }
 }
 
 impl ToParams for Service {
     fn to_params(&self) -> Vec<(&str, &str)> {
-        let mut res = vec![("service_id", self.service_id.as_str())];
+        let mut res = vec![("service_id", self.service_id.as_ref())];
         let creds = self.creds.to_params();
         res.extend(creds);
         res


### PR DESCRIPTION
Similar to #5 but this time for the Service module.

@unleashed, we might want to divide these modules in the future. They're growing fast with all those trait implementations.