### PR TITLE
Add getters for Request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -17,4 +17,19 @@ impl Request {
     pub fn new(method: String, path: String, body: Option<String>) -> Request {
         Request { method, path, body }
     }
+
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn body(&self) -> Option<&str> {
+        match self.body {
+            Some(ref body) => Some(body.as_str()),
+            _ => None
+        }
+    }
 }


### PR DESCRIPTION
Simple PR. I was writing some tests and noticed that we don't have any getters in `Request`.