### PR TITLE
Fix travis build by specifying binutils-dev as a dependency instead of libbfd-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ addons:
       - libdw-dev
       - cmake
       - gcc
-      - libbfd-dev
+      - binutils-dev
       - libiberty-dev
 
 install:


### PR DESCRIPTION
This PR fixes the error we are getting in Travis:
```
  Package libbfd-dev is a virtual package provided by:
    binutils-2.26-dev 2.26.1-1ubuntu1~14.04
    binutils-dev 2.24-5ubuntu14.2
  E: Package 'libbfd-dev' has no installation candidate
```