### PR TITLE
misc: update to Rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     # Linux
     #- env: TARGET=i686-unknown-linux-gnu
     #- env: TARGET=i686-unknown-linux-musl
-    - env: TARGET=x86_64-unknown-linux-gnu
+    #- env: TARGET=x86_64-unknown-linux-gnu
     #- env: TARGET=x86_64-unknown-linux-musl
 
     # OSX

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "threescalers"
 version = "0.1.0"
 authors = ["Alejandro Martinez Ruiz <alex@flawedcode.org>", "David Ortiz Lopez <z.david.ortiz@gmail.com>"]

--- a/src/apicall.rs
+++ b/src/apicall.rs
@@ -1,7 +1,7 @@
-use request::{Request, ToRequest};
-use service::Service;
-use application::Application;
-use user::User;
+use crate::request::{Request, ToRequest};
+use crate::service::Service;
+use crate::application::Application;
+use crate::user::User;
 
 #[derive(Debug)]
 pub enum Type {
@@ -54,7 +54,7 @@ impl<'service, 'app, 'user> Info<'service, 'app, 'user> {
     }
 
     fn params(&self) -> Vec<(&str, &str)> {
-        use request::ToParams;
+        use crate::request::ToParams;
 
         let mut params: Vec<(&str, &str)> = Vec::new();
         params.extend(self.service.to_params());

--- a/src/apicall.rs
+++ b/src/apicall.rs
@@ -13,7 +13,7 @@ pub enum Type {
 impl Type {
     pub fn method(&self) -> &str {
         use self::Type::*;
-        match *self {
+        match self {
             Report => "POST",
             AuthRep | Authorize => "GET",
         }
@@ -43,13 +43,13 @@ impl<'service, 'app, 'user> Info<'service, 'app, 'user> {
         use self::Type::*;
 
         match (&self.kind, self.application, self.user) {
-            (&Authorize, &Application::OAuthToken(_), _) => OAUTH_AUTHORIZE_ENDPOINT,
-            (&Authorize, _, Some(&User::OAuthToken(_))) => OAUTH_AUTHORIZE_ENDPOINT,
-            (&Authorize, _, _) => AUTHORIZE_ENDPOINT,
-            (&AuthRep, &Application::OAuthToken(_), _) => OAUTH_AUTHREP_ENDPOINT,
-            (&AuthRep, _, Some(&User::OAuthToken(_))) => OAUTH_AUTHREP_ENDPOINT,
-            (&AuthRep, _, _) => AUTHREP_ENDPOINT,
-            (&Report, _, _) => REPORT_ENDPOINT,
+            (Authorize, Application::OAuthToken(_), _) => OAUTH_AUTHORIZE_ENDPOINT,
+            (Authorize, _, Some(&User::OAuthToken(_))) => OAUTH_AUTHORIZE_ENDPOINT,
+            (Authorize, _, _) => AUTHORIZE_ENDPOINT,
+            (AuthRep, Application::OAuthToken(_), _) => OAUTH_AUTHREP_ENDPOINT,
+            (AuthRep, _, Some(&User::OAuthToken(_))) => OAUTH_AUTHREP_ENDPOINT,
+            (AuthRep, _, _) => AUTHREP_ENDPOINT,
+            (Report, _, _) => REPORT_ENDPOINT,
         }
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,5 @@
-use request::ToParams;
-use errors::*;
+use crate::request::ToParams;
+use crate::errors::*;
 
 use std::str::FromStr;
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -211,16 +211,16 @@ impl ToParams for Application {
         use self::Application::*;
 
         let mut v = Vec::<(&str, &str)>::with_capacity(2);
-        match *self {
-            AppId(ref app_id, None) => {
+        match self {
+            AppId(app_id, None) => {
                 v.push(("app_id", app_id.as_ref()));
             },
-            AppId(ref app_id, Some(ref app_key)) => {
+            AppId(app_id, Some(app_key)) => {
                 v.push(("app_id", app_id.as_ref()));
                 v.push(("app_key", app_key.as_ref()));
             },
-            UserKey(ref user_key) => v.push(("user_key", user_key.as_ref())),
-            OAuthToken(ref token) => v.push(("access_token", token.as_ref())),
+            UserKey(user_key) => v.push(("user_key", user_key.as_ref())),
+            OAuthToken(token) => v.push(("access_token", token.as_ref())),
         };
 
         v

--- a/src/service.rs
+++ b/src/service.rs
@@ -45,14 +45,14 @@ impl FromStr for ServiceToken {
 }
 
 // These trait impls are similar to FromStr (but are infallible)
-impl<'a> From<&'a str> for ProviderKey where Self: FromStr {
-    fn from(s: &'a str) -> ProviderKey {
+impl From<&str> for ProviderKey where Self: FromStr {
+    fn from(s: &str) -> ProviderKey {
         s.parse().unwrap()
     }
 }
 
-impl<'a> From<&'a str> for ServiceToken where Self: FromStr {
-    fn from(s: &'a str) -> ServiceToken {
+impl From<&str> for ServiceToken where Self: FromStr {
+    fn from(s: &str) -> ServiceToken {
         s.parse().unwrap()
     }
 }
@@ -146,8 +146,8 @@ impl FromStr for ServiceId {
     }
 }
 
-impl<'a> From<&'a str> for ServiceId where Self: FromStr {
-    fn from(s: &'a str) -> ServiceId {
+impl From<&str> for ServiceId where Self: FromStr {
+    fn from(s: &str) -> ServiceId {
         s.parse().unwrap()
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -114,9 +114,9 @@ impl ToParams for Credentials {
     fn to_params(&self) -> Vec<(&str, &str)> {
         use self::Credentials::*;
 
-        let (field, value) = match *self {
-            ProviderKey(ref key) => ("provider_key", key.as_ref()),
-            ServiceToken(ref token) => ("service_token", token.as_ref())
+        let (field, value) = match self {
+            ProviderKey(key) => ("provider_key", key.as_ref()),
+            ServiceToken(token) => ("service_token", token.as_ref())
         };
 
         vec![(field, value)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,5 +1,5 @@
-use request::ToParams;
-use errors::*;
+use crate::request::ToParams;
+use crate::errors::*;
 
 use std::str::FromStr;
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
-use request::ToParams;
-use errors::*;
+use crate::request::ToParams;
+use crate::errors::*;
 
 use std::str::FromStr;
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -39,14 +39,14 @@ impl FromStr for OAuthToken {
 }
 
 // These trait impls are similar to FromStr (but are infallible)
-impl<'a> From<&'a str> for UserId where Self: FromStr {
-    fn from(s: &'a str) -> UserId {
+impl From<&str> for UserId where Self: FromStr {
+    fn from(s: &str) -> UserId {
         s.parse().unwrap()
     }
 }
 
-impl<'a> From<&'a str> for OAuthToken where Self: FromStr {
-    fn from(s: &'a str) -> OAuthToken {
+impl From<&str> for OAuthToken where Self: FromStr {
+    fn from(s: &str) -> OAuthToken {
         s.parse().unwrap()
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -112,9 +112,9 @@ impl User {
 
 impl ToParams for User {
     fn to_params(&self) -> Vec<(&str, &str)> {
-        let (field, value) = match *self {
-            User::UserId(ref user_id) => ("user_id", user_id.as_ref()),
-            User::OAuthToken(ref token) => ("access_token", token.as_ref())
+        let (field, value) = match self {
+            User::UserId(user_id) => ("user_id", user_id.as_ref()),
+            User::OAuthToken(token) => ("access_token", token.as_ref())
         };
         vec![(field, value)]
     }

--- a/tests/apicall.rs
+++ b/tests/apicall.rs
@@ -8,7 +8,7 @@ use threescalers::user::*;
 
 use std::collections::HashMap;
 
-use helpers::*;
+use crate::helpers::*;
 
 #[test]
 fn returns_auth_request_from_service_id_pkey_and_app_id() {


### PR DESCRIPTION
This is the result of running `cargo fix --edition`, adding the proper flag
to Cargo.toml and removing some superfluous syntax.