### PR TITLE
application: use From trait instead of Into

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -128,27 +128,27 @@ pub enum Application {
 }
 
 // These trait impls build an Application variant out of its required types
-impl Into<Application> for AppId {
-    fn into(self) -> Application {
-        Application::AppId(self, None)
+impl From<AppId> for Application {
+    fn from(a: AppId) -> Self {
+        Application::AppId(a, None)
     }
 }
 
-impl Into<Application> for (AppId, AppKey) {
-    fn into(self) -> Application {
-        Application::AppId(self.0, Some(self.1))
+impl From<(AppId, AppKey)> for Application {
+    fn from(a: (AppId, AppKey)) -> Self {
+        Application::AppId(a.0, Some(a.1))
     }
 }
 
-impl Into<Application> for UserKey {
-    fn into(self) -> Application {
-        Application::UserKey(self)
+impl From<UserKey> for Application {
+    fn from(u: UserKey) -> Self {
+        Application::UserKey(u)
     }
 }
 
-impl Into<Application> for OAuthToken {
-    fn into(self) -> Application {
-        Application::OAuthToken(self)
+impl From<OAuthToken> for Application {
+    fn from(o: OAuthToken) -> Self {
+        Application::OAuthToken(o)
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -232,6 +232,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn convert_application_from_app_id() {
+        let app_id = AppId::from("my_app_id");
+        let app = Application::from(app_id.clone());
+
+        assert_eq!(Application::AppId(app_id, None), app);
+    }
+
+    #[test]
+    fn convert_application_from_app_id_app_key() {
+        let app_id_key = (AppId::from("my_app_id"), AppKey::from("my_app_key"));
+        let app = Application::from(app_id_key.clone());
+
+        assert_eq!(Application::AppId(app_id_key.0, Some(app_id_key.1)), app);
+    }
+
+    #[test]
+    fn convert_application_from_user_key() {
+        let user_key = UserKey::from("my_user_key");
+        let app = Application::from(user_key.clone());
+
+        assert_eq!(Application::UserKey(user_key), app);
+    }
+
+    #[test]
+    fn convert_application_from_oauth_token() {
+        let token = OAuthToken::from("my_oauth_token");
+        let app = Application::from(token.clone());
+
+        assert_eq!(Application::OAuthToken(token), app);
+    }
+
+    #[test]
     fn transforms_app_id_into_params() {
         let app_id = "my_app_id";
         let app = Application::from_app_id(app_id);

--- a/src/application.rs
+++ b/src/application.rs
@@ -3,13 +3,13 @@ use crate::errors::*;
 
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AppId(String);
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AppKey(String);
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UserKey(String);
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct OAuthToken(String);
 
 // These trait impls provide a way to reference our types as &str
@@ -120,7 +120,7 @@ impl From<String> for OAuthToken {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Application {
     AppId(AppId, Option<AppKey>),
     UserKey(UserKey),


### PR DESCRIPTION
This PR makes the ergonomics of `Application` a bit better by
using the `From` trait.

The reason is that `Into<T>` does not have a corresponding trait
automatically defined as `From<U>`. And in turn, the reason for this
is that, besides avoiding a circular reference that would conflict
with existing `From` impls (and without specialization that'd be an
error), it is not always possible to define a `From<U>` trait due to
coherence rules, but you can always define an `Into<T>` trait.

At https://doc.rust-lang.org/std/convert/trait.Into.html you can see
the paragraph below:

Library authors should not directly implement this trait, but should
prefer implementing the `From` trait, which offers greater flexibility
and provides an equivalent Into implementation for free, thanks to a
blanket implementation in the standard library.

The greater flexibility comes from the blanket `Into` implementation.
Additionally, check out the problem about not always being able to
implement `From<T>` (ie. you can't `impl From<T> for Vec<T>`) at:

https://doc.rust-lang.org/std/convert/trait.Into.html#implementing-into