### PR TITLE
Update trust CI system

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
-# Based on the "trust" template v0.1.1
-# https://github.com/japaric/trust/tree/v0.1.1
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
 
 environment:
   global:
@@ -22,10 +22,10 @@ environment:
     #- TARGET: x86_64-pc-windows-msvc
 
     # Testing other channels
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: nightly
-    #- TARGET: x86_64-pc-windows-msvc
+    #- TARGET: x86_64-pc-windows-gnu
     #  RUST_VERSION: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: nightly
 
 install:
   - ps: >-
@@ -43,15 +43,13 @@ install:
 # TODO This is the "test phase", tweak it as you see fit
 test_script:
   # we don't run the "test phase" when doing deploys
-      #cargo build --target %TARGET% &&
-      #cargo build --target %TARGET% --release &&
-      #cargo test --target %TARGET% &&
-      #cargo test --target %TARGET% --release &&
       #cargo run --target %TARGET% &&
       #cargo run --target %TARGET% --release
   - if [%APPVEYOR_REPO_TAG%]==[false] (
       cargo build --target %TARGET% &&
-      cargo test --target %TARGET%
+      cargo build --target %TARGET% --release &&
+      cargo test --target %TARGET% &&
+      cargo test --target %TARGET% --release
     )
 
 # We don't have a deploy phase

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# Based on the "trust" template v0.1.1
-# https://github.com/japaric/trust/tree/v0.1.1
+# Based on the "trust" template v0.1.2
+# https://github.com/japaric/trust/tree/v0.1.2
 
 dist: trusty
 language: rust
@@ -18,9 +18,39 @@ matrix:
   # TODO These are all the build jobs. Adjust as necessary. Comment out what you
   # don't need
   include:
+    # Android
+    #- env: TARGET=aarch64-linux-android DISABLE_TESTS=1
+    #- env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
+    #- env: TARGET=armv7-linux-androideabi DISABLE_TESTS=1
+    #- env: TARGET=i686-linux-android DISABLE_TESTS=1
+    #- env: TARGET=x86_64-linux-android DISABLE_TESTS=1
+
+    # iOS
+    #- env: TARGET=aarch64-apple-ios DISABLE_TESTS=1
+    #  os: osx
+    #- env: TARGET=armv7-apple-ios DISABLE_TESTS=1
+    #  os: osx
+    #- env: TARGET=armv7s-apple-ios DISABLE_TESTS=1
+    #  os: osx
+    #- env: TARGET=i386-apple-ios DISABLE_TESTS=1
+    #  os: osx
+    #- env: TARGET=x86_64-apple-ios DISABLE_TESTS=1
+    #  os: osx
+
     # Linux
+    #- env: TARGET=aarch64-unknown-linux-gnu
+    #- env: TARGET=arm-unknown-linux-gnueabi
+    #- env: TARGET=armv7-unknown-linux-gnueabihf
     #- env: TARGET=i686-unknown-linux-gnu
     #- env: TARGET=i686-unknown-linux-musl
+    #- env: TARGET=mips-unknown-linux-gnu
+    #- env: TARGET=mips64-unknown-linux-gnuabi64
+    #- env: TARGET=mips64el-unknown-linux-gnuabi64
+    #- env: TARGET=mipsel-unknown-linux-gnu
+    #- env: TARGET=powerpc-unknown-linux-gnu
+    #- env: TARGET=powerpc64-unknown-linux-gnu
+    #- env: TARGET=powerpc64le-unknown-linux-gnu
+    #- env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
     #- env: TARGET=x86_64-unknown-linux-gnu
     #- env: TARGET=x86_64-unknown-linux-musl
 
@@ -35,17 +65,16 @@ matrix:
     #- env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     #- env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
-    # Other architectures
-    #- env: TARGET=aarch64-unknown-linux-gnu
-    #- env: TARGET=armv7-unknown-linux-gnueabihf
-    #- env: TARGET=mips-unknown-linux-gnu
-    #- env: TARGET=mips64-unknown-linux-gnuabi64
-    #- env: TARGET=mips64el-unknown-linux-gnuabi64
-    #- env: TARGET=mipsel-unknown-linux-gnu
-    #- env: TARGET=powerpc-unknown-linux-gnu
-    #- env: TARGET=powerpc64-unknown-linux-gnu
-    #- env: TARGET=powerpc64le-unknown-linux-gnu
-    #- env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+    # Windows
+    #- env: TARGET=x86_64-pc-windows-gnu
+
+    # Bare metal
+    # These targets don't support std and as such are likely not suitable for
+    # most crates.
+    # - env: TARGET=thumbv6m-none-eabi
+    # - env: TARGET=thumbv7em-none-eabi
+    # - env: TARGET=thumbv7em-none-eabihf
+    # - env: TARGET=thumbv7m-none-eabi
 
     # Testing other channels
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -56,6 +85,7 @@ matrix:
 
 before_install:
   - set -e
+  - rustup self update
   - sudo apt-get update
 
 addons:
@@ -76,16 +106,18 @@ install:
 before_script:
   - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
-        ( ( cargo install clippy && export CLIPPY=true ) || export CLIPPY=false );
+        ( ( rustup component add clippy && export CLIPPY=true ) || export CLIPPY=false );
+        ( ( rustup component add rustfmt && export RUSTFMT=true ) || export RUSTFMT=false );
       fi
 
-  - rustup component add rustfmt
-
 script:
-  - cargo fmt --all -- --check
+  - |
+      if [[ "$TRAVIS_RUST_VERSION" == "nightly" && "${RUSTFMT}" == "true" ]]; then
+        cargo fmt --all -- --check
+      fi
   - bash ci/script.sh
   - |
-      if [[ "$TRAVIS_RUST_VERSION" == "nightly" && $CLIPPY ]]; then
+      if [[ "$TRAVIS_RUST_VERSION" == "nightly" && "${CLIPPY}" == "true" ]]; then
         cargo clippy
       fi
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,6 +10,26 @@ main() {
         sort=gsort  # for `sort --sort-version`, from brew's coreutils.
     fi
 
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
     # This fetches latest stable release
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
                        | cut -d/ -f3 \


### PR DESCRIPTION
Update the travis & appveyor templates + ci scripts to latest master in trust.

Note that tests might fail while I tune this.

And also:
* With the update avoids installing rust twice in newer images from Travis.
* Ensures rustfmt is installed via rustup.
* Correctly limits checks with clippy and rustfmt to nightly.
* Tests the two windows toolchains in appveyor.