### PR TITLE
Remove warnings about unused imports

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,4 @@
-use error_chain::{
-    error_chain, error_chain_processing, impl_error_chain_kind, impl_error_chain_processed,
-    impl_extract_backtrace,
-};
+use error_chain::error_chain;
 
 error_chain! {
     errors {

--- a/tests/api_call.rs
+++ b/tests/api_call.rs
@@ -586,7 +586,6 @@ fn returns_auth_request_from_service_id_token_oauth_token_and_oauth_user() {
 mod helpers {
     use std::borrow::Cow;
     use std::collections::HashMap;
-    use std::hash::Hash;
 
     pub fn vec_to_hash<'a, V: Copy>(vec: &'a Vec<(Cow<str>, V)>) -> HashMap<&'a str, V> {
         let mut h: HashMap<&str, V> = HashMap::new();


### PR DESCRIPTION
These were either left-overs or required back in the time where this library moved to the 2018 edition, and no longer required (error_chain ones).