### PR TITLE
Cargo.toml: specify caret reqs in dependencies for publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ reqwest-sync = ["reqwest"]
 reqwest-all = ["reqwest-async", "reqwest-sync"]
 
 [dependencies]
-error-chain = "*"
-percent-encoding = "*"
-http_types = { version = "*", package = "http" }
-reqwest = { version = "*", optional = true }
+error-chain = "^0.12"
+percent-encoding = "^1"
+http_types = { version = "^0.1", package = "http" }
+reqwest = { version = "^0.9", optional = true }


### PR DESCRIPTION
This is required to be able to publish the library on crates.io. The idea is to keep these as relaxed as possible while trying to ensure compatibility.