### PR TITLE
Instrument travis phases and enable testing on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,18 +106,30 @@ install:
 before_script:
   - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+        echo "--== [RUSTUP] Adding clippy & rustfmt ==--";
         ( ( rustup component add clippy && export CLIPPY=true ) || export CLIPPY=false );
         ( ( rustup component add rustfmt && export RUSTFMT=true ) || export RUSTFMT=false );
       fi
 
 script:
   - |
+      /bin/echo -e "--== [INFO] Build Environment ==--\n\n" \
+        "TRAVIS_OS_NAME       = ${TRAVIS_OS_NAME}\n" \
+        "TRAVIS_RUST_VERSION  = ${TRAVIS_RUST_VERSION}\n" \
+        "TRAVIS_REPO_SLUG     = ${TRAVIS_REPO_SLUG}\n" \
+        "TRAVIS_PULL_REQUEST  = ${TRAVIS_PULL_REQUEST}\n" \
+        "TRAVIS_BRANCH        = ${TRAVIS_BRANCH}\n" \
+        "CLIPPY               = ${CLIPPY}\n" \
+        "RUSTFMT              = ${RUSTFMT}\n"
+  - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" && "${RUSTFMT}" == "true" ]]; then
+        echo "--== [FMT] cargo fmt check ==--" &&
         cargo fmt --all -- --check
       fi
   - bash ci/script.sh
   - |
       if [[ "$TRAVIS_RUST_VERSION" == "nightly" && "${CLIPPY}" == "true" ]]; then
+        echo "--== [CLIPPY] Running ==--" &&
         cargo clippy
       fi
 
@@ -129,10 +141,12 @@ after_script: set +e
 after_success:
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" && "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
+        echo "--== [DOCS] Generating ==--" &&
         cargo doc && echo '<meta http-equiv=refresh content="0; url=threescalers/index.html">' > target/doc/index.html && git clone https://github.com/davisp/ghp-import.git && ghp-import/ghp_import.py -n -p -f -m "Documentation upload" -r https://"$GH_TOKEN"@github.com/"$TRAVIS_REPO_SLUG.git" target/doc && echo "Uploaded documentation"
       fi
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable" ]]; then
+        echo "--== [KCOV] Building ==--" &&
         wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
         tar xzf master.tar.gz &&
         cd kcov-master &&
@@ -144,7 +158,9 @@ after_success:
         cd ../.. &&
         rm -rf kcov-master &&
         cargo test &&
+        echo "--== [KCOV] Running ==--" &&
         for file in $(find target/debug -maxdepth 1 -type f -perm /111); do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+        echo "--== [KCOV] Uploading ==--" &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     #- env: TARGET=powerpc64-unknown-linux-gnu
     #- env: TARGET=powerpc64le-unknown-linux-gnu
     #- env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-    #- env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=x86_64-unknown-linux-gnu
     #- env: TARGET=x86_64-unknown-linux-musl
 
     # OSX

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ http-request = []
 reqwest-async = ["reqwest"]
 reqwest-sync = ["reqwest"]
 reqwest-all = ["reqwest-async", "reqwest-sync"]
+# Internal feature, auto-enabled via build.rs when using nightly
+nightly = []
 
 [dependencies]
 error-chain = "^0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ error-chain = "^0.12"
 percent-encoding = "^1"
 http_types = { version = "^0.1", package = "http" }
 reqwest = { version = "^0.9", optional = true }
+
+[build-dependencies]
+rustc_version = "^0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+// Detect nightly compilers.
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    if version_meta().unwrap().channel == Channel::Nightly {
+        println!("cargo:rustc-cfg=feature=\"nightly\"");
+    }
+}

--- a/src/http/parameters.rs
+++ b/src/http/parameters.rs
@@ -120,8 +120,8 @@ impl Parameters {
     }
 }
 
-#[cfg(test)]
-mod tests {
+#[cfg(all(test, feature = "nightly"))]
+mod benches {
     use super::*;
     use test::Bencher;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
-#[cfg(test)]
+#[cfg(all(test, feature = "nightly"))]
 extern crate test;
 
 pub mod api_call;


### PR DESCRIPTION
We generate the docs on master and coverage with stable, so let's enable it again.

Update: now we set a `nightly` feature flag to detect nightly compilers and run benchmarks (since they are only available on nightly and require enabling a feature flag and importing a crate).